### PR TITLE
Create github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,16 @@
+---
+name: "\U0001F4AC Discussion"
+about: "I want to discuss a question or concept."
+title: ''
+labels: 'discussion'
+assignees: ''
+
+---
+
+## Discussion
+
+**What do you want to talk about?**
+A clear and concise description of the discussion you want, and why you want it.
+
+**Relevant resources**
+A list of anything you think someone should look at in order to engage.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: "\U0001F4A1 Feature Request"
+about: "I have a suggestion (and may want to implement it)!"
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Teachability, Documentation, Adoption, Migration Strategy**
+If you can, explain how users will be able to use this and possibly write out a version the docs.
+Maybe a screenshot or design?

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,19 @@
+---
+name: "\U00002692 Team Task"
+about: "Something needs doing"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Task
+
+**Description**
+A clear and concise description of what needs to be done
+
+**Relevant resources / research**
+Any links or ideas that you've already collected related to the task
+
+**Related Issues**
+A list of related issues

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+{ This PR adds ... }
+
+{ This PR fixes ... }
+
+{ This PR removes ... }
+
+## Due Diligence Checklist
+- [ ] Tests
+- [ ] Documentation
+- [ ] Consolidated commits
+- [ ] Relevant labels assigned
+
+## Steps to Test
+1. `yarn test`
+
+## Deploy Notes
+- { `yarn install` }
+- { `yarn migrate` }
+- { Populate environment variables ... }
+- { Set up ... }
+
+## Related Issues
+Resolves {X}
+
+Related to {Y}


### PR DESCRIPTION
This adds templates for PRs as well as three types of issue.  They are borrowed from the https://github.com/tvkitchen/tv-kitchen project

Gone are the day of having to remember what kind of information to include in a code process action!

Resolves #9 